### PR TITLE
fix: /rank command fails as student role when no information has insi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ questions.json
 firebase_config.json
 __pycache__/
 
+venv/

--- a/commands/level_commands.py
+++ b/commands/level_commands.py
@@ -23,7 +23,14 @@ def register(tree: app_commands.CommandTree):
             update_last_interaction(interaction.guild.id)
 
             leaderboard = get_leaderboard(str(interaction.guild.id), limit=5)
-
+            leaderboard = get_leaderboard(str(interaction.guild.id), limit=5)
+            if not leaderboard or len(leaderboard) == 0:
+                await interaction.response.send_message(
+                "📊 No leaderboard data available yet!\n"
+                "Complete some quizzes to appear on the leaderboard.",
+                ephemeral=True
+            )
+                return
             msg = "🏆 **Leaderboard**\n"
             for idx, (user_id, xp, level) in enumerate(leaderboard, start=1):
                 user = await interaction.guild.fetch_member(user_id)


### PR DESCRIPTION
This PR fixes /rank command.

Fix: #35
<img width="911" height="207" alt="image" src="https://github.com/user-attachments/assets/10e332a9-af88-458e-8d15-e4fec6945159" />

Previously, the system failed when no user was registered.
Now, when no users are registered, a proper message is shown instead.