### PR TITLE
Fix: Handle Empty Leaderboard and Missing Users in `/rank` Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ questions.json
 
 firebase_config.json
 __pycache__/
+venv/
 

--- a/commands/level_commands.py
+++ b/commands/level_commands.py
@@ -24,10 +24,20 @@ def register(tree: app_commands.CommandTree):
 
             leaderboard = get_leaderboard(str(interaction.guild.id), limit=5)
 
+            if not leaderboard:
+                await interaction.response.send_message(
+                    "No one has earned XP yet. Start answering questions to get on the leaderboard!",
+                    ephemeral=True
+                )
+                return
+
             msg = "🏆 **Leaderboard**\n"
             for idx, (user_id, xp, level) in enumerate(leaderboard, start=1):
-                user = await interaction.guild.fetch_member(user_id)
-                msg += f"{idx}. {user.display_name} — {xp} XP (Level {level})\n"
+                try:
+                    user = await interaction.guild.fetch_member(user_id)
+                    msg += f"{idx}. {user.display_name} — {xp} XP (Level {level})\n"
+                except:
+                    continue
 
             await interaction.response.send_message(msg)
 


### PR DESCRIPTION
FIX : #35 
- Empty leaderboard check: Returns friendly message when no users have XP
- Missing user handling: Skips users who left the server instead of crashing


https://github.com/user-attachments/assets/527d1268-2060-4fd1-8db5-e483287579b0

