### PR TITLE
Fix/ issue 36

### DIFF
--- a/commands/level_commands.py
+++ b/commands/level_commands.py
@@ -65,6 +65,7 @@ def register(tree: app_commands.CommandTree):
             )
 
     @tree.command(name="user_rank", description="Display the specified user's rank")
+    @app_commands.default_permissions(administrator=True)
     @app_commands.describe(user_name="User full name")
     async def user_rank(interaction: discord.Interaction, user_name: str):
         try:

--- a/commands/questions_commands.py
+++ b/commands/questions_commands.py
@@ -14,6 +14,7 @@ from utils.utils import professor_verification, update_last_interaction, autocom
 def register(tree: app_commands.CommandTree):
 
     @tree.command(name="add_question", description="Add a question to a topic (Professors only)")
+    @app_commands.default_permissions(administrator=True)
     @app_commands.describe(
         topic="Topic name",
         question="Question text",
@@ -55,6 +56,7 @@ def register(tree: app_commands.CommandTree):
                 pass
 
     @tree.command(name="list_questions", description="List questions for a topic (Professors only)")
+    @app_commands.default_permissions(administrator=True)
     @app_commands.describe(topic="Topic name")
     @app_commands.autocomplete(topic=autocomplete_topics)
     async def list_questions_command(interaction: Interaction, topic: str):
@@ -103,6 +105,7 @@ def register(tree: app_commands.CommandTree):
                 pass
 
     @tree.command(name="delete_question", description="Delete a question by ID (Professors only)")
+    @app_commands.default_permissions(administrator=True)
     @app_commands.describe(topic="Topic name", id="Question ID (string)")
     @app_commands.autocomplete(topic=autocomplete_topics)
     async def delete_question_command(interaction: Interaction, topic: str, id: str):
@@ -123,6 +126,7 @@ def register(tree: app_commands.CommandTree):
                 pass
 
     @tree.command(name="generate_questions", description="Generate multiple questions for a topic (Professors only)")
+    @app_commands.default_permissions(administrator=True)
     @app_commands.describe(topic="Topic name", qty="Quantity of new questions", type="Question type")
     @app_commands.autocomplete(topic=autocomplete_topics, type=autocomplete_question_type)
     async def generate_questions_command(interaction: Interaction, topic: str, qty: int, type: str):

--- a/commands/stats_commands.py
+++ b/commands/stats_commands.py
@@ -14,6 +14,7 @@ from utils.structured_logging import structured_logger as logger
 def register(tree: app_commands.CommandTree):
 
     @tree.command(name="stats", description="Shows a summary of the quizzes taken by all users (professors only)")
+    @app_commands.default_permissions(administrator=True)
     async def stats(interaction: discord.Interaction):
 
         try:
@@ -55,6 +56,7 @@ def register(tree: app_commands.CommandTree):
                 logging.error("Failed to send error message to user")
             
     @tree.command(name="user_stats", description="Shows a summary of quiz attempts per user (professors only)")
+    @app_commands.default_permissions(administrator=True)
     async def user_stats(interaction: discord.Interaction):
         try:
             update_server_last_interaction(interaction.guild.id)
@@ -149,6 +151,7 @@ def register(tree: app_commands.CommandTree):
                 logging.error("Failed to send error message to user")
 
     @tree.command(name="time_stats", description="Shows a summary of the quizzes taken over time (professors only)")
+    @app_commands.default_permissions(administrator=True)
     async def time_stats(interaction: discord.Interaction):
         try:
             update_server_last_interaction(interaction.guild.id)

--- a/commands/topics_commands.py
+++ b/commands/topics_commands.py
@@ -83,6 +83,7 @@ def register(tree: app_commands.CommandTree):
     # UPLOAD PDF WITHOUT GENERATING QUESTIONS
     ###
     @tree.command(name="upload_pdf", description="Saves the PDF without generating questions")
+    @app_commands.default_permissions(administrator=True)
     @app_commands.describe(topic_name="Name of the topic to save the PDF under", file="PDF file with content")
     async def upload_pdf_command(interaction: discord.Interaction, topic_name: str, file: discord.Attachment):
         await interaction.response.defer(thinking=True, ephemeral=True)
@@ -129,6 +130,7 @@ def register(tree: app_commands.CommandTree):
     # UPLOAD PDF AND GENERATE QUESTIONS AUTOMATICALLY
     ###
     @tree.command(name="upload_topic", description="Uploads a PDF and automatically generates questions")
+    @app_commands.default_permissions(administrator=True)
     @app_commands.describe(topic_name="Name of the topic to save the PDF under", file="PDF file with content")
     async def upload_pdf_with_questions(interaction: discord.Interaction, topic_name: str, file: discord.Attachment):
         await interaction.response.defer(thinking=True, ephemeral=True)


### PR DESCRIPTION
I've implemented a permission check for professor-only commands using default_permissions. I tested it with two accounts: one as an Administrator (Professor) and another as a regular Member (Student)  As shown in the screenshots, the restricted commands are now completely hidden from the student's command list 
<img width="1343" height="357" alt="image" src="https://github.com/user-attachments/assets/4e16ad74-f3ed-4ea5-ba32-416284ce8ad6" />
