### PR TITLE
Fix: generate questions command was not incrementing num_quizzes_generated in firebase

### DIFF
--- a/repositories/topic_repository.py
+++ b/repositories/topic_repository.py
@@ -1,5 +1,5 @@
 import logging
-from firebase_init import db, bucket, SERVER_TIMESTAMP
+from firebase_init import db, bucket, SERVER_TIMESTAMP, Increment
 
 
 def list_topics(guild_id):
@@ -54,6 +54,12 @@ def create_topic_with_questions(guild_id, topic_title, topic_id, new_questions, 
                 "failures": 0
             })
         batch.commit()
+
+        if topic_id is not None:
+            topic_ref.update({
+                "num_quizzes_generated": Increment(len(new_questions))
+            })
+
         logging.info(
             f"Topic '{topic_title}' with questions created/updated in server {guild_id} (ID: {use_topic_id})")
         return use_topic_id


### PR DESCRIPTION
Fixes an issue where the `generate_questions` command was not incrementing `num_quizzes_generated` in Firebase, ensuring quiz generation statistics are updated correctly.
