### PR TITLE
Fix: increment num_quizes_generated when new questions are added

### DIFF
--- a/repositories/topic_repository.py
+++ b/repositories/topic_repository.py
@@ -1,5 +1,5 @@
 import logging
-from firebase_init import db, bucket, SERVER_TIMESTAMP
+from firebase_init import db, bucket, SERVER_TIMESTAMP, Increment
 
 
 def list_topics(guild_id):
@@ -53,6 +53,12 @@ def create_topic_with_questions(guild_id, topic_title, topic_id, new_questions, 
                 "success": 0,
                 "failures": 0
             })
+            
+        if topic_id is not None:
+            topic_ref.update({
+                "num_quizzes_generated": Increment(len(new_questions))
+            })
+
         batch.commit()
         logging.info(
             f"Topic '{topic_title}' with questions created/updated in server {guild_id} (ID: {use_topic_id})")


### PR DESCRIPTION
This pull request introduces an update to the topic creation logic in `topic_repository.py` to incrementally track the number of quizzes generated for a topic. The main change is the use of an atomic increment operation when questions are added to a topic.
