### PR TITLE
Feature: improved delete_question adding a deleting interface

### DIFF
--- a/commands/questions_commands.py
+++ b/commands/questions_commands.py
@@ -7,6 +7,8 @@ from utils.enum import QuestionType
 from utils.llm_utils import generate_questions_from_pdf
 from utils.structured_logging import structured_logger as logger
 from utils.utils import professor_verification, update_last_interaction, autocomplete_question_type, is_professor, autocomplete_topics, autocomplete_all_topics, autocomplete_TF, safe_defer
+from views.delete_question_view import DeleteQuestionView
+
 
 # Register commands
 
@@ -106,11 +108,11 @@ def register(tree: app_commands.CommandTree):
             except Exception:
                 pass
 
-    @tree.command(name="delete_question", description="Delete a question by ID (Professors only)")
+    @tree.command(name="delete_question", description="Delete a question interactively (Professors only)")
     @app_commands.default_permissions(administrator=True)
-    @app_commands.describe(topic="Topic name", id="Question ID (string)")
+    @app_commands.describe(topic="Topic name")
     @app_commands.autocomplete(topic=autocomplete_topics)
-    async def delete_question_command(interaction: Interaction, topic: str, id: str):
+    async def delete_question_command(interaction: Interaction, topic: str):
         if not await professor_verification(interaction):
             return
         if not await safe_defer(interaction, thinking=True, ephemeral=True):
@@ -119,8 +121,41 @@ def register(tree: app_commands.CommandTree):
         try:
             update_last_interaction(interaction.guild.id)
 
-            delete_question(interaction.guild.id, topic, id)
-            await interaction.followup.send(f"🗑️ Deleted question with ID `{id}` from `{topic}`", ephemeral=True)
+            questions = list_questions_by_topic(interaction.guild.id, topic)
+
+            if not questions:
+                await interaction.followup.send(
+                    f"📭 No questions found for `{topic}`.",
+                    ephemeral=True,
+                )
+                return
+
+            blocks = []
+            current_block = (
+                f"📚 Questions for `{topic}`:\n"
+                "Click the button below to open a modal and type the number to delete.\n\n"
+            )
+
+            for i, q in enumerate(questions, start=1):
+                line = f"{i}. {q['question']} (Answer: {q['correct_answer']})\n"
+                if len(current_block) + len(line) > 2000:
+                    blocks.append(current_block)
+                    current_block = ""
+                current_block += line
+
+            if current_block:
+                blocks.append(current_block)
+
+            delete_view = DeleteQuestionView(
+                guild_id=interaction.guild.id,
+                topic=topic,
+                questions=questions,
+                owner_user_id=interaction.user.id,
+            )
+
+            await interaction.followup.send(blocks[0], ephemeral=True, view=delete_view)
+            for block in blocks[1:]:
+                await interaction.followup.send(block, ephemeral=True)
 
         except Exception as e:
             try:

--- a/views/delete_question_view.py
+++ b/views/delete_question_view.py
@@ -1,0 +1,95 @@
+import discord
+from discord import Interaction
+
+from repositories.question_repository import delete_question
+
+
+class DeleteQuestionModal(discord.ui.Modal, title="Delete Question"):
+    def __init__(self, guild_id: int, topic: str, questions: list[dict]):
+        super().__init__()
+        self.guild_id = guild_id
+        self.topic = topic
+        self.questions = questions
+
+        self.number_input = discord.ui.TextInput(
+            label="Question number",
+            placeholder=f"Enter a number between 1 and {len(questions)}",
+            required=True,
+            max_length=6,
+        )
+        self.add_item(self.number_input)
+
+    async def on_submit(self, interaction: Interaction):
+        try:
+            # Acknowledge immediately to avoid "Unknown interaction" if DB work takes too long.
+            await interaction.response.defer(ephemeral=True, thinking=False)
+
+            user_input = str(self.number_input.value).strip()
+            if not user_input.isdigit():
+                await interaction.followup.send(
+                    "❌ Invalid input. You must type numbers only.",
+                    ephemeral=True,
+                )
+                return
+
+            number = int(user_input)
+            if number < 1 or number > len(self.questions):
+                await interaction.followup.send(
+                    f"❌ Invalid number `{number}`. It must be between 1 and {len(self.questions)}.",
+                    ephemeral=True,
+                )
+                return
+
+            question_to_delete = self.questions[number - 1]
+            delete_question(self.guild_id, self.topic, question_to_delete["id"])
+            await interaction.followup.send(
+                f"🗑️ Question #{number} deleted from `{self.topic}`.",
+                ephemeral=True,
+            )
+
+        except Exception as e:
+            try:
+                await interaction.followup.send(
+                    f"❌ Failed to delete question: {e}",
+                    ephemeral=True,
+                )
+            except Exception:
+                pass
+
+
+class DeleteQuestionView(discord.ui.View):
+    def __init__(self, guild_id: int, topic: str, questions: list[dict], owner_user_id: int):
+        super().__init__(timeout=120)
+        self.guild_id = guild_id
+        self.topic = topic
+        self.questions = questions
+        self.owner_user_id = owner_user_id
+        self._consumed = False
+
+    @discord.ui.button(label="Enter question number", style=discord.ButtonStyle.danger)
+    async def open_modal(self, interaction: Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.owner_user_id:
+            await interaction.response.send_message(
+                "⚠️ Only the user who started this command can use this action.",
+                ephemeral=True,
+            )
+            return
+
+        if self._consumed:
+            await interaction.response.send_message(
+                "⚠️ This action was already used. Run `/delete_question` again if needed.",
+                ephemeral=True,
+            )
+            return
+
+        self._consumed = True
+
+        # Remove the button from the original message so it cannot be reused.
+        try:
+            await interaction.message.edit(view=None)
+        except Exception:
+            pass
+
+        await interaction.response.send_modal(
+            DeleteQuestionModal(self.guild_id, self.topic, self.questions)
+        )


### PR DESCRIPTION
This pull request updates the question deletion workflow to provide an interactive, user-friendly experience for professors. Instead of requiring a question ID, professors can now select and delete questions by number through a Discord modal dialog. The main changes introduce a new interactive view and modal for deletion, update the command signature, and improve error handling and user feedback.