### PR TITLE
Fix: delete question in a more easy way

### DIFF
--- a/commands/questions_commands.py
+++ b/commands/questions_commands.py
@@ -7,11 +7,32 @@ from utils.enum import QuestionType
 from utils.llm_utils import generate_questions_from_pdf
 from utils.structured_logging import structured_logger as logger
 from utils.utils import professor_verification, update_last_interaction, autocomplete_question_type, is_professor, autocomplete_topics, autocomplete_all_topics, autocomplete_TF, safe_defer
+from views.delete_question_view import DeleteQuestionView
 
 # Register commands
 
 
 def register(tree: app_commands.CommandTree):
+
+    def _build_question_blocks(topic: str, questions: list):
+        blocks = []
+        current_block = f"📚 Questions for '{topic}':\n"
+
+        for i, q in enumerate(questions, start=1):
+            question_text = q.get("question", "No question text")
+            answer_text = q.get("correct_answer", "N/A")
+            line = f"{i}. {question_text} (Answer: {answer_text})\n"
+
+            if len(current_block) + len(line) > 2000:
+                blocks.append(current_block)
+                current_block = ""
+
+            current_block += line
+
+        if current_block:
+            blocks.append(current_block)
+
+        return blocks
 
     @tree.command(name="add_question", description="Add a question to a topic (Professors only)")
     @app_commands.default_permissions(administrator=True)
@@ -106,11 +127,11 @@ def register(tree: app_commands.CommandTree):
             except Exception:
                 pass
 
-    @tree.command(name="delete_question", description="Delete a question by ID (Professors only)")
+    @tree.command(name="delete_question", description="Delete a question by number (Professors only)")
     @app_commands.default_permissions(administrator=True)
-    @app_commands.describe(topic="Topic name", id="Question ID (string)")
+    @app_commands.describe(topic="Topic name")
     @app_commands.autocomplete(topic=autocomplete_topics)
-    async def delete_question_command(interaction: Interaction, topic: str, id: str):
+    async def delete_question_command(interaction: Interaction, topic: str):
         if not await professor_verification(interaction):
             return
         if not await safe_defer(interaction, thinking=True, ephemeral=True):
@@ -119,8 +140,30 @@ def register(tree: app_commands.CommandTree):
         try:
             update_last_interaction(interaction.guild.id)
 
-            delete_question(interaction.guild.id, topic, id)
-            await interaction.followup.send(f"🗑️ Deleted question with ID `{id}` from `{topic}`", ephemeral=True)
+            questions = list_questions_by_topic(interaction.guild.id, topic)
+
+            if not questions:
+                await interaction.followup.send(f"📭 No questions found for '{topic}'.", ephemeral=True)
+                return
+
+            blocks = _build_question_blocks(topic, questions)
+            await interaction.followup.send(blocks[0], ephemeral=True)
+            for block in blocks[1:]:
+                await interaction.followup.send(block, ephemeral=True)
+
+            view = DeleteQuestionView(
+                requester_id=interaction.user.id,
+                guild_id=interaction.guild.id,
+                topic=topic,
+                questions=questions
+            )
+            button_message = await interaction.followup.send(
+                "🧩 Click the button to enter the number.",
+                view=view,
+                ephemeral=True,
+                wait=True
+            )
+            view.message = button_message
 
         except Exception as e:
             try:

--- a/views/delete_question_view.py
+++ b/views/delete_question_view.py
@@ -1,0 +1,120 @@
+import asyncio
+import logging
+import discord
+from discord import Interaction
+from discord.ui import View, Button, Modal, TextInput
+
+from repositories.question_repository import delete_question
+
+class DeleteQuestionView(View):
+    def __init__(self, requester_id: int, guild_id: int, topic: str, questions: list):
+        super().__init__(timeout=120)
+        self.message = None
+        self.used = False
+        self.add_item(
+            OpenDeleteQuestionModalButton(
+                requester_id=requester_id,
+                guild_id=guild_id,
+                topic=topic,
+                questions=questions
+            )
+        )
+
+class OpenDeleteQuestionModalButton(Button):
+    def __init__(self, requester_id: int, guild_id: int, topic: str, questions: list):
+        super().__init__(
+            label="Enter number privately",
+            style=discord.ButtonStyle.danger
+        )
+        self.requester_id = requester_id
+        self.guild_id = guild_id
+        self.topic = topic
+        self.questions = questions
+
+    async def callback(self, interaction: Interaction):
+        if interaction.user.id != self.requester_id:
+            await interaction.response.send_message(
+                "❌ Only the command author can use this button.",
+                ephemeral=True
+            )
+            return
+
+        if self.view.used:
+            await interaction.response.send_message(
+                "⚠️ This action was already used.",
+                ephemeral=True
+            )
+            return
+
+        self.view.used = True
+
+        await interaction.response.send_modal(
+            DeleteQuestionModal(
+                guild_id=self.guild_id,
+                topic=self.topic,
+                questions=self.questions,
+                source_view=self.view
+            )
+        )
+
+class DeleteQuestionModal(Modal, title="Delete question"):
+    question_number = TextInput(
+        label="Question number",
+        placeholder="Example: 3",
+        required=True,
+        max_length=5
+    )
+
+    def __init__(self, guild_id: int, topic: str, questions: list, source_view: View):
+        super().__init__(timeout=120)
+        self.guild_id = guild_id
+        self.topic = topic
+        self.questions = questions
+        self.source_view = source_view
+
+    async def on_submit(self, interaction: Interaction):
+        try:
+            await interaction.response.defer(ephemeral=True, thinking=True)
+
+            user_input = str(self.question_number.value).strip()
+            if not user_input.isdigit():
+                await interaction.followup.send("❌ Invalid input. You must send a number.", ephemeral=True)
+                return
+
+            selected_number = int(user_input)
+            if selected_number < 1 or selected_number > len(self.questions):
+                await interaction.followup.send(
+                    f"❌ Invalid number. Choose between 1 and {len(self.questions)}.",
+                    ephemeral=True
+                )
+                return
+
+            selected_question = self.questions[selected_number - 1]
+            selected_question_id = selected_question.get("id")
+            if not selected_question_id:
+                await interaction.followup.send("❌ Could not resolve question ID.", ephemeral=True)
+                return
+
+            await asyncio.to_thread(delete_question, self.guild_id, self.topic, selected_question_id)
+
+            # Oculta el botón después del primer uso
+            if self.source_view and getattr(self.source_view, "message", None):
+                self.source_view.clear_items()
+                self.source_view.stop()
+                try:
+                    await self.source_view.message.edit(
+                        content="✅ Delete action already used.",
+                        view=None
+                    )
+                except Exception:
+                    pass
+
+            selected_text = selected_question.get("question", "N/A")
+            await interaction.followup.send(
+                f"🗑️ Deleted question #{selected_number} from '{self.topic}': {selected_text}",
+                ephemeral=True
+            )
+
+        except Exception as e:
+            logging.error(f"Error deleting question from modal: {e}")
+            await interaction.followup.send(f"❌ Failed to delete question: {e}", ephemeral=True)


### PR DESCRIPTION
This pull request refactors the process for deleting questions in the Discord bot, making it more user-friendly and interactive. Instead of deleting questions by ID, professors can now select and delete questions by number using an interactive button and modal dialog. The implementation introduces a new view for managing the deletion workflow and improves error handling and user feedback.