### PR TITLE
Feature: topic_stats command show a report of the statistics from a topic

### DIFF
--- a/commands/stats_commands.py
+++ b/commands/stats_commands.py
@@ -7,7 +7,7 @@ import discord
 
 from repositories import stats_repository, quiz_repository
 from repositories.server_repository import update_server_last_interaction
-from utils.utils import is_professor, professor_verification, safe_defer
+from utils.utils import is_professor, professor_verification, safe_defer, autocomplete_all_topics
 from utils.structured_logging import structured_logger as logger
 
 
@@ -215,3 +215,121 @@ def register(tree: app_commands.CommandTree):
                 await interaction.followup.send(f"❌ Error retrieving statistics. {e}", ephemeral=True)
             except Exception:
                 logging.error("Failed to send error message to user")
+
+    @tree.command(name="topic_stats", description="Muestra estadísticas detalladas de un tópico (solo profesorado)")
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.describe(topic="Nombre del tópico")
+    @app_commands.autocomplete(topic=autocomplete_all_topics)
+    async def topic_stats(interaction: discord.Interaction, topic: str):
+        try:
+            if interaction.guild_id is None:
+                await interaction.response.send_message(
+                    "⛔ Este comando solo puede usarse dentro de un servidor.",
+                    ephemeral=True
+                )
+                return
+
+            update_server_last_interaction(interaction.guild_id)
+
+            if not await professor_verification(interaction):
+                return
+
+            if not await safe_defer(interaction, thinking=True, ephemeral=True):
+                return
+
+            data = stats_repository.get_topic_statistics(interaction.guild_id, topic)
+
+            if not data:
+                await interaction.followup.send(
+                    f"📂 No se encontró el tópico '{topic}' o no hay datos disponibles.",
+                    ephemeral=True
+                )
+                return
+
+            def short_question(text: str, limit: int = 90):
+                return text if len(text) <= limit else text[:limit - 3] + "..."
+
+            top_success_lines = []
+            for i, q in enumerate(data["top_success_questions"], start=1):
+                top_success_lines.append(
+                    f"{i}. {short_question(q['question'])} ({q['success']} aciertos)"
+                )
+
+            top_failure_lines = []
+            for i, q in enumerate(data["top_failure_questions"], start=1):
+                top_failure_lines.append(
+                    f"{i}. {short_question(q['question'])} ({q['failures']} fallos)"
+                )
+
+            if not top_success_lines:
+                top_success_lines.append("Sin datos suficientes.")
+            if not top_failure_lines:
+                top_failure_lines.append("Sin datos suficientes.")
+
+            msg = (
+                f"📊 Estadísticas del tópico\n\n"
+                f"Topico: {data['topic']}\n"
+                f"Total aciertos: {data['total_success']}\n"
+                f"Total fallos: {data['total_failures']}\n"
+                f"Total respuestas: {data['total_answers']}\n"
+                f"% acierto global: {data['accuracy']:.2f}%\n\n"
+                f"Top 3 preguntas con más aciertos:\n" + "\n".join(top_success_lines) + "\n\n"
+                f"Top 3 preguntas con más fallos:\n" + "\n".join(top_failure_lines) + "\n\n"
+                f"Conclusión: {data['conclusion']}"
+            )
+
+            # --- Pie chart: correct vs failed ---
+            fig, ax = plt.subplots(figsize=(5, 5))
+
+            correct = data["total_success"]
+            failed = data["total_failures"]
+            total = data["total_answers"]
+
+            if total > 0:
+                sizes = [correct, failed]
+                labels = ["Aciertos", "Fallos"]
+                colors = ["#2E8B57", "#C0392B"]
+
+                ax.pie(
+                    sizes,
+                    labels=labels,
+                    colors=colors,
+                    autopct="%1.1f%%",
+                    startangle=90,
+                    wedgeprops={"edgecolor": "white", "linewidth": 1.2}
+                )
+                ax.set_title(f"Distribucion de respuestas - {data['topic']}")
+            else:
+                # Evita error de matplotlib cuando todo es 0
+                ax.pie(
+                    [1],
+                    labels=["Sin respuestas"],
+                    colors=["#95A5A6"],
+                    startangle=90,
+                    wedgeprops={"edgecolor": "white", "linewidth": 1.2}
+                )
+                ax.set_title(f"Distribucion de respuestas - {data['topic']}")
+
+            ax.axis("equal")
+
+            buf = io.BytesIO()
+            plt.tight_layout()
+            plt.savefig(buf, format="png", dpi=150)
+            buf.seek(0)
+            plt.close(fig)
+
+            await interaction.followup.send(
+                content=msg,
+                file=File(fp=buf, filename="topic_stats_pie.png"),
+                ephemeral=True
+            )
+
+        except Exception as e:
+            logging.error(f"Error in /topic_stats: {e}")
+            try:
+                await interaction.followup.send(
+                    "❌ Error al obtener estadísticas del tópico.",
+                    ephemeral=True
+                )
+            except Exception:
+                pass

--- a/repositories/stats_repository.py
+++ b/repositories/stats_repository.py
@@ -1,4 +1,5 @@
 from firebase_init import db, SERVER_TIMESTAMP
+from repositories.topic_repository import get_topic_by_name, get_questions_by_topic
 import logging
 
 
@@ -49,3 +50,61 @@ def get_statistics_by_server(guild_id: int):
         logging.error(
             f"❌ Error fetching statistics for server {guild_id}: {e}")
         return {}
+
+def get_topic_statistics(guild_id: int, topic: str):
+    try:
+        topic_data = get_topic_by_name(guild_id, topic)
+        if not topic_data:
+            return None
+
+        question_docs = get_questions_by_topic(guild_id, topic)
+        questions = [doc.to_dict() for doc in question_docs] if question_docs else []
+
+        normalized = []
+        for q in questions:
+            text = str(q.get("question", "Pregunta sin texto")).strip()
+            success = int(q.get("success", 0) or 0)
+            failures = int(q.get("failures", 0) or 0)
+            normalized.append({
+                "question": text,
+                "success": success,
+                "failures": failures
+            })
+
+        total_success = sum(q["success"] for q in normalized)
+        total_failures = sum(q["failures"] for q in normalized)
+        total_answers = total_success + total_failures
+        accuracy = (total_success / total_answers * 100.0) if total_answers > 0 else 0.0
+
+        top_success = sorted(
+            normalized,
+            key=lambda x: (x["success"], -x["failures"]),
+            reverse=True
+        )[:3]
+
+        top_failures = sorted(
+            normalized,
+            key=lambda x: (x["failures"], -x["success"]),
+            reverse=True
+        )[:3]
+
+        conclusion = (
+            "El tópico no está bien comprendido."
+            if accuracy < 50.0
+            else "El tópico está comprendido."
+        )
+
+        return {
+            "topic": topic_data.get("title", topic),
+            "total_success": total_success,
+            "total_failures": total_failures,
+            "total_answers": total_answers,
+            "accuracy": accuracy,
+            "top_success_questions": top_success,
+            "top_failure_questions": top_failures,
+            "conclusion": conclusion
+        }
+
+    except Exception as e:
+        logging.error(f"❌ Error fetching topic statistics for '{topic}' in server {guild_id}: {e}")
+        return None


### PR DESCRIPTION
This pull request introduces a new command for professors to view detailed statistics about quiz topics, including a summary, top questions, and a pie chart visualization. It also adds the backend logic to aggregate and return topic-specific statistics.
