### PR TITLE
Fix: manualy add short answer questions and refactorized whole command

### DIFF
--- a/commands/questions_commands.py
+++ b/commands/questions_commands.py
@@ -7,54 +7,99 @@ from utils.enum import QuestionType
 from utils.llm_utils import generate_questions_from_pdf
 from utils.structured_logging import structured_logger as logger
 from utils.utils import professor_verification, update_last_interaction, autocomplete_question_type, is_professor, autocomplete_topics, autocomplete_all_topics, autocomplete_TF, safe_defer
+from views.add_question_modals import AddTrueFalseQuestionModal, AddShortAnswerQuestionModal, AddMultipleChoiceQuestionModal
+
+
+def _resolve_question_type(raw_type: str) -> QuestionType | None:
+    try:
+        return QuestionType(raw_type)
+    except ValueError:
+        normalized_type = str(raw_type).strip().upper().replace(" ", "_")
+        if normalized_type in QuestionType.__members__:
+            return QuestionType[normalized_type]
+        return None
 
 # Register commands
 
-
 def register(tree: app_commands.CommandTree):
-
+    
     @tree.command(name="add_question", description="Add a question to a topic (Professors only)")
     @app_commands.default_permissions(administrator=True)
     @app_commands.describe(
         topic="Topic name",
         question="Question text",
-        answer="Correct answer (T or F)"
+        type="Question type",
     )
-    @app_commands.autocomplete(topic=autocomplete_all_topics, answer=autocomplete_TF)
-    async def add_question_command(interaction: Interaction, topic: str, question: str, answer: str):
-        # Immediate defer to avoid Discord timeout (3 seconds)
+    @app_commands.autocomplete(topic=autocomplete_all_topics, type=autocomplete_question_type)
+    async def add_question_command(
+        interaction: Interaction,
+        topic: str,
+        question: str,
+        type: str,
+    ):
         if not await professor_verification(interaction):
-            return
-        if not await safe_defer(interaction, thinking=True, ephemeral=True):
             return
 
         try:
-            update_last_interaction(interaction.guild.id)
-
-            if answer.upper() not in ["T", "F"]:
-                await interaction.followup.send("❌ Answer must be 'V' or 'F'", ephemeral=True)
-                logger.warning(f"❌ Invalid answer in /add_question: {answer}",
-                               command="add_question",
-                               user_id=str(interaction.user.id),
-                               username=interaction.user.display_name,
-                               guild_id=str(
-                                   interaction.guild.id) if interaction.guild else None,
-                               invalid_answer=answer,
-                               operation="validation_error")
+            guild_id = interaction.guild.id if interaction.guild else interaction.guild_id
+            if guild_id is None:
+                await interaction.response.send_message(
+                    "❌ This command can only be used in a server.",
+                    ephemeral=True,
+                )
                 return
 
-            new_id = add_question(interaction.guild.id,
-                                  topic, question, answer.upper())
-            await interaction.followup.send(
-                f"✅ Question added to `{topic}` with ID: `{new_id}`.",
-                ephemeral=True
-            )
+            update_last_interaction(guild_id)
+
+            if not str(question).strip():
+                await interaction.response.send_message("❌ Question cannot be empty.", ephemeral=True)
+                return
+
+            topic_data = get_topic_by_name(guild_id, topic)
+            if not topic_data:
+                await interaction.response.send_message(
+                    f"❌ Topic '{topic}' does not exist.",
+                    ephemeral=True,
+                )
+                return
+
+            question_type = _resolve_question_type(type)
+            if not question_type:
+                await interaction.response.send_message(
+                    f"❌ Invalid question type: {type}",
+                    ephemeral=True,
+                )
+                return
+
+            if question_type == QuestionType.TRUE_FALSE:
+                await interaction.response.send_modal(
+                    AddTrueFalseQuestionModal(topic=topic, question=question)
+                )
+            elif question_type == QuestionType.SHORT_ANSWER:
+                await interaction.response.send_modal(
+                    AddShortAnswerQuestionModal(topic=topic, question=question)
+                )
+            elif question_type == QuestionType.MULTIPLE_CHOICE:
+                await interaction.response.send_modal(
+                    AddMultipleChoiceQuestionModal(topic=topic, question=question)
+                )
+            else:
+                await interaction.response.send_message(
+                    f"❌ Unsupported question type: {question_type.value}",
+                    ephemeral=True,
+                )
 
         except Exception as e:
-            try:
-                await interaction.followup.send(f"❌ Failed to add question: {e}", ephemeral=True)
-            except Exception:
-                pass
+            if interaction.response.is_done():
+                try:
+                    await interaction.followup.send(f"❌ Failed to start add question flow: {e}", ephemeral=True)
+                except Exception:
+                    pass
+            else:
+                await interaction.response.send_message(
+                    f"❌ Failed to start add question flow: {e}",
+                    ephemeral=True,
+                )
 
     @tree.command(name="list_questions", description="List questions for a topic (Professors only)")
     @app_commands.default_permissions(administrator=True)

--- a/repositories/question_repository.py
+++ b/repositories/question_repository.py
@@ -1,5 +1,6 @@
 import logging
 from firebase_init import db, Increment
+from utils.enum import QuestionType
 
 
 def _get_topic_ref_by_name(guild_id: int, topic: str):
@@ -39,15 +40,42 @@ def list_questions_by_topic(guild_id: int, topic: str):
         return []
 
 
-def add_question(guild_id: int, topic: str, question: str, answer: str):
+def add_question(
+    guild_id: int,
+    topic: str,
+    question: str,
+    answer: str,
+    qtype: QuestionType,
+    alternatives: dict | None = None,
+):
     try:
         topic_doc_ref = _get_topic_ref_by_name(guild_id, topic)
         questions_ref = topic_doc_ref.collection("questions")
 
+        normalized_answer = str(answer).strip()
+        alternatives = alternatives or {}
+
+        if qtype == QuestionType.TRUE_FALSE:
+            stored_alternatives = {"T": "True", "F": "False"}
+        elif qtype == QuestionType.MULTIPLE_CHOICE:
+            stored_alternatives = {
+                "A": str(alternatives.get("A", "")).strip(),
+                "B": str(alternatives.get("B", "")).strip(),
+                "C": str(alternatives.get("C", "")).strip(),
+                "D": str(alternatives.get("D", "")).strip(),
+            }
+        else:
+            stored_alternatives = {}
+
         new_ref = questions_ref.document()
         new_ref.set({
+            "question_id": new_ref.id,
             "question": question,
-            "correct_answer": answer
+            "correct_answer": normalized_answer,
+            "question_type": qtype.value,
+            "alternatives": stored_alternatives,
+            "success": 0,
+            "failures": 0
         })
         topic_doc_ref.update({
             "num_quizzes_generated": Increment(1)
@@ -57,7 +85,7 @@ def add_question(guild_id: int, topic: str, question: str, answer: str):
     except Exception as e:
         logging.error(
             f"Error adding question to topic '{topic}' in server {guild_id}: {e}")
-        raise  # re-raise the error for external handling if needed
+        raise
 
 
 def delete_question(guild_id: int, topic: str, question_id: str):

--- a/utils/enum.py
+++ b/utils/enum.py
@@ -3,3 +3,4 @@ from enum import Enum
 class QuestionType(Enum):
     MULTIPLE_CHOICE = "Multiple Choice"
     TRUE_FALSE = "True or False"
+    SHORT_ANSWER = "Short Answer"

--- a/views/add_question_modals.py
+++ b/views/add_question_modals.py
@@ -1,0 +1,164 @@
+import discord
+from discord import Interaction
+from discord.ui import Modal, TextInput
+
+from repositories.question_repository import add_question
+from utils.enum import QuestionType
+from utils.utils import safe_defer, update_last_interaction
+
+
+class AddQuestionBaseModal(Modal):
+    def __init__(self, *, topic: str, question: str, question_type: QuestionType, title: str):
+        super().__init__(title=title, timeout=180)
+        self.topic = topic
+        self.question = question
+        self.question_type = question_type
+
+    async def _save_question(
+        self,
+        interaction: Interaction,
+        answer: str,
+        alternatives: dict | None = None,
+    ):
+        deferred = False
+        try:
+            guild_id = interaction.guild.id if interaction.guild else interaction.guild_id
+            if guild_id is None:
+                await interaction.response.send_message(
+                    "❌ This command can only be used in a server.",
+                    ephemeral=True,
+                )
+                return
+
+            # A modal submission must be acknowledged quickly to avoid Discord timeout.
+            deferred = await safe_defer(interaction, thinking=False, ephemeral=True)
+            if not deferred:
+                return
+
+            update_last_interaction(guild_id)
+            new_id = add_question(
+                guild_id,
+                self.topic,
+                self.question,
+                answer,
+                self.question_type,
+                alternatives or {},
+            )
+            await interaction.followup.send(
+                f"✅ {self.question_type.value} question added to {self.topic} with ID: {new_id}.",
+                ephemeral=True,
+            )
+        except Exception as e:
+            if deferred or interaction.response.is_done():
+                await interaction.followup.send(f"❌ Failed to add question: {e}", ephemeral=True)
+            else:
+                await interaction.response.send_message(
+                    f"❌ Failed to add question: {e}",
+                    ephemeral=True,
+                )
+
+
+class AddTrueFalseQuestionModal(AddQuestionBaseModal):
+    correct_answer = TextInput(
+        label="Correct answer (True/False)",
+        placeholder="Write True or False",
+        required=True,
+        max_length=10,
+    )
+
+    def __init__(self, *, topic: str, question: str):
+        super().__init__(
+            topic=topic,
+            question=question,
+            question_type=QuestionType.TRUE_FALSE,
+            title="Add True/False Question",
+        )
+
+    async def on_submit(self, interaction: Interaction):
+        raw_answer = str(self.correct_answer.value).strip().upper()
+        if raw_answer.startswith("T"):
+            normalized_answer = "T"
+        elif raw_answer.startswith("F"):
+            normalized_answer = "F"
+        else:
+            await interaction.response.send_message(
+                "❌ True/False answer must be True or False.",
+                ephemeral=True,
+            )
+            return
+
+        await self._save_question(interaction, normalized_answer)
+
+
+class AddShortAnswerQuestionModal(AddQuestionBaseModal):
+    correct_answer = TextInput(
+        label="Correct answer",
+        placeholder="Write the expected short answer",
+        required=True,
+        max_length=400,
+        style=discord.TextStyle.paragraph,
+    )
+
+    def __init__(self, *, topic: str, question: str):
+        super().__init__(
+            topic=topic,
+            question=question,
+            question_type=QuestionType.SHORT_ANSWER,
+            title="Add Short Answer Question",
+        )
+
+    async def on_submit(self, interaction: Interaction):
+        normalized_answer = str(self.correct_answer.value).strip()
+        if not normalized_answer:
+            await interaction.response.send_message("❌ Answer cannot be empty.", ephemeral=True)
+            return
+
+        await self._save_question(interaction, normalized_answer)
+
+
+class AddMultipleChoiceQuestionModal(AddQuestionBaseModal):
+    option_a = TextInput(label="Option A", required=True, max_length=300)
+    option_b = TextInput(label="Option B", required=True, max_length=300)
+    option_c = TextInput(label="Option C", required=True, max_length=300)
+    option_d = TextInput(label="Option D", required=True, max_length=300)
+    correct_option = TextInput(
+        label="Correct option (A/B/C/D)",
+        placeholder="Example: B",
+        required=True,
+        max_length=4,
+    )
+
+    def __init__(self, *, topic: str, question: str):
+        super().__init__(
+            topic=topic,
+            question=question,
+            question_type=QuestionType.MULTIPLE_CHOICE,
+            title="Add Multiple Choice Question",
+        )
+
+    async def on_submit(self, interaction: Interaction):
+        alternatives = {
+            "A": str(self.option_a.value).strip(),
+            "B": str(self.option_b.value).strip(),
+            "C": str(self.option_c.value).strip(),
+            "D": str(self.option_d.value).strip(),
+        }
+
+        for letter, text in alternatives.items():
+            if not text:
+                await interaction.response.send_message(
+                    f"❌ Option {letter} cannot be empty.",
+                    ephemeral=True,
+                )
+                return
+
+        answer_raw = str(self.correct_option.value).strip().upper()
+        normalized_answer = answer_raw[:1] if answer_raw else ""
+        if normalized_answer not in {"A", "B", "C", "D"}:
+            await interaction.response.send_message(
+                "❌ Correct option must be one of A/B/C/D.",
+                ephemeral=True,
+            )
+            return
+
+        await self._save_question(interaction, normalized_answer, alternatives)


### PR DESCRIPTION
This pull request introduces significant improvements to the question-adding workflow for professors in the Discord bot, enabling support for multiple question types (True/False, Short Answer, Multiple Choice) through interactive modals. The changes modernize the `/add_question` command, add new modal classes for each question type, and refactor the database schema to accommodate richer question data.